### PR TITLE
♻️ refactoring: from `okp4` to `axone`

### DIFF
--- a/.github/ISSUE_TEMPLATE/register-validator.yml
+++ b/.github/ISSUE_TEMPLATE/register-validator.yml
@@ -1,5 +1,5 @@
 name: ⚖️ Register Validator
-description: Submit a request to register your validator node in the genesis of an OKP4 network.
+description: Submit a request to register your validator node in the genesis of an Axone network.
 title: "⚖️ Register Validator: "
 labels: ["register-validator"]
 assignees:
@@ -12,7 +12,7 @@ body:
     id: network
     attributes:
       label: Network Choice
-      description: Choose the OKP4 network you want to join
+      description: Choose the Axone network you want to join
       multiple: false
       options:
         - drunemeton-1
@@ -47,4 +47,4 @@ body:
   - type: markdown
     attributes:
       value: |
-        🙏 Thanks for your interest in OKP4, for now we can let [botanik](https://github.com/bot-anik) take care of the technical part of your request before entering the review process.
+        🙏 Thanks for your interest in Axone, for now we can let [botanik](https://github.com/bot-anik) take care of the technical part of your request before entering the review process.

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -12,5 +12,5 @@ jobs:
     steps:
       - uses: actions/add-to-project@v1.0.0
         with:
-          project-url: https://github.com/orgs/okp4/projects/9
-          github-token: ${{ secrets.OKP4_TOKEN }}
+          project-url: https://github.com/orgs/axone-protocol/projects/2
+          github-token: ${{ secrets.OPS_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,4 +13,4 @@ jobs:
         uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
           target: patch
-          github-token: ${{ secrets.OKP4_TOKEN }}
+          github-token: ${{ secrets.OPS_TOKEN }}

--- a/.github/workflows/follow-contributor.yml
+++ b/.github/workflows/follow-contributor.yml
@@ -12,4 +12,4 @@ jobs:
         uses: okp4/follow-contributor-action@v1.1.0
         with:
           username: ${{ github.event.pull_request.user.login }}
-          token: ${{ secrets.OKP4_TOKEN }}
+          token: ${{ secrets.OPS_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -115,5 +115,5 @@ jobs:
 
       - name: Check genesis files
         run: |
-          echo "🔎 Checking 'okp4-${{ matrix.context.network }}' genesis"
-          docker run --rm -v ${GITHUB_WORKSPACE}/${{ matrix.context.path }}/${{ matrix.context.name }}:/genesis.json okp4/okp4d:`cat ./chains/${{ matrix.context.network }}/version.txt` genesis validate /genesis.json
+          echo "🔎 Checking 'axone-${{ matrix.context.network }}' genesis"
+          docker run --rm -v ${GITHUB_WORKSPACE}/${{ matrix.context.path }}/${{ matrix.context.name }}:/genesis.json axone-protocol/axoned:`cat ./chains/${{ matrix.context.network }}/version.txt` genesis validate /genesis.json

--- a/.github/workflows/register-validator.yml
+++ b/.github/workflows/register-validator.yml
@@ -97,14 +97,14 @@ jobs:
         if: ${{ failure() }}
         uses: andymckay/labeler@master
         with:
-          repo-token: ${{ secrets.OKP4_TOKEN }}
+          repo-token: ${{ secrets.OPS_TOKEN }}
           add-labels: "invalid"
 
       - name: Add failure comment
         if: ${{ failure() }}
         uses: peter-evans/create-or-update-comment@v4
         with:
-          token: ${{ secrets.OKP4_TOKEN }}
+          token: ${{ secrets.OPS_TOKEN }}
           issue-number: ${{ github.event.issue.number }}
           body: |
             😢 I couldn't process your request: `${{ steps.check-gentx.outputs.error }}`
@@ -118,6 +118,15 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.BOT_GPG_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
       - name: Process gentx
         id: add-gentx
         env:
@@ -129,13 +138,13 @@ jobs:
           echo "$GENTX" > chains/${{ needs.resolve-context.outputs.network }}/gentx/gentx-${{ github.event.issue.number }}.json
 
           mkdir -p $NODE_HOME
-          docker run --rm --user $(id -u):$(id -g) -v $NODE_HOME:$NODE_HOME okp4/okp4d:`cat ./chains/${{ needs.resolve-context.outputs.network }}/version.txt` init --home $NODE_HOME whatever
+          docker run --rm --user $(id -u):$(id -g) -v $NODE_HOME:$NODE_HOME axone-protocol/axoned:`cat ./chains/${{ needs.resolve-context.outputs.network }}/version.txt` init --home $NODE_HOME whatever
           cp chains/${{ needs.resolve-context.outputs.network }}/genesis.json $NODE_HOME/config/genesis.json
 
           delegator_balance="`expr ${{ fromJson(needs.resolve-context.outputs.register-config).delegation.amount }} + 200000`${{ fromJson(needs.resolve-context.outputs.register-config).delegation.denom }}"
-          docker run --rm --user $(id -u):$(id -g) -v $NODE_HOME:$NODE_HOME okp4/okp4d:`cat ./chains/${{ needs.resolve-context.outputs.network }}/version.txt` genesis add-genesis-account --home $NODE_HOME $DELEGATOR_ADDR $delegator_balance
+          docker run --rm --user $(id -u):$(id -g) -v $NODE_HOME:$NODE_HOME axone-protocol/axoned:`cat ./chains/${{ needs.resolve-context.outputs.network }}/version.txt` genesis add-genesis-account --home $NODE_HOME $DELEGATOR_ADDR $delegator_balance
 
-          docker run --rm --user $(id -u):$(id -g) -v $NODE_HOME:$NODE_HOME -v $PWD/chains/${{ needs.resolve-context.outputs.network }}/gentx:/gentx okp4/okp4d:`cat ./chains/${{ needs.resolve-context.outputs.network }}/version.txt` genesis collect-gentxs --home $NODE_HOME --gentx-dir /gentx
+          docker run --rm --user $(id -u):$(id -g) -v $NODE_HOME:$NODE_HOME -v $PWD/chains/${{ needs.resolve-context.outputs.network }}/gentx:/gentx axone-protocol/axoned:`cat ./chains/${{ needs.resolve-context.outputs.network }}/version.txt` genesis collect-gentxs --home $NODE_HOME --gentx-dir /gentx
           cp $NODE_HOME/config/genesis.json chains/${{ needs.resolve-context.outputs.network }}/genesis.json
 
       - name: Prepare commit message
@@ -162,9 +171,9 @@ jobs:
         with:
           commit-message: |
             ${{ steps.commit-message.outputs.message }}
-          committer: ${{ secrets.OKP4_BOT_GIT_COMMITTER_NAME }} <${{ secrets.OKP4_BOT_GIT_COMMITTER_EMAIL }}>
-          author: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }} <${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}>
-          token: ${{ secrets.OKP4_TOKEN }}
+          committer: ${{ vars.BOT_GIT_COMMITTER_NAME }} <${{ vars.BOT_GIT_COMMITTER_EMAIL }}>
+          author: ${{ vars.BOT_GIT_AUTHOR_NAME }} <${{ vars.BOT_GIT_AUTHOR_EMAIL }}>
+          token: ${{ secrets.OPS_TOKEN }}
           branch: feat/${{ github.event.issue.number }}-register-${{ needs.resolve-context.outputs.network }}
           title: '⚖️ Register `${{ needs.resolve-context.outputs.moniker }}` Validator'
           body: |
@@ -176,7 +185,7 @@ jobs:
       - name: Link PR
         uses: peter-evans/create-or-update-comment@v4
         with:
-          token: ${{ secrets.OKP4_TOKEN }}
+          token: ${{ secrets.OPS_TOKEN }}
           issue-number: ${{ github.event.issue.number }}
           body: |
             😉 Here is the corresponding PR: ${{ steps.open-pr.outputs.pull-request-url }}
@@ -185,13 +194,13 @@ jobs:
         if: ${{ failure() }}
         uses: andymckay/labeler@master
         with:
-          repo-token: ${{ secrets.OKP4_TOKEN }}
+          repo-token: ${{ secrets.OPS_TOKEN }}
           add-labels: "invalid"
 
       - name: Add failure comment
         if: ${{ failure() }}
         uses: peter-evans/create-or-update-comment@v4
         with:
-          token: ${{ secrets.OKP4_TOKEN }}
+          token: ${{ secrets.OPS_TOKEN }}
           issue-number: ${{ github.event.issue.number }}
           body: 😢 I couldn't process your request...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,9 +66,9 @@ jobs:
       - name: Initialize blockchain
         run: |
 
-          docker run --rm -v ${GITHUB_WORKSPACE}/${{ matrix.context.path }}:/.okp4d okp4/okp4d:`cat ./chains/${{ matrix.context.network }}/version.txt` \
+          docker run --rm -v ${GITHUB_WORKSPACE}/${{ matrix.context.path }}:/.axoned axone-protocol/axoned:`cat ./chains/${{ matrix.context.network }}/version.txt` \
               keys add validator \
-              --home /.okp4d \
+              --home /.axoned \
               --keyring-backend test
 
           jq --arg date "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" '.genesis_time = $date' ${GITHUB_WORKSPACE}/${{ matrix.context.path }}/${{ matrix.context.name }} > ${GITHUB_WORKSPACE}/${{ matrix.context.path }}/${{ matrix.context.name }}-tmp
@@ -76,27 +76,27 @@ jobs:
           sudo mkdir -p ${GITHUB_WORKSPACE}/${{ matrix.context.path }}/config/gentx
           sudo cp ${GITHUB_WORKSPACE}/${{ matrix.context.path }}/gentx/*  ${GITHUB_WORKSPACE}/${{ matrix.context.path }}/config/gentx
 
-          docker run --rm -v ${GITHUB_WORKSPACE}/${{ matrix.context.path }}:/.okp4d okp4/okp4d:`cat ./chains/${{ matrix.context.network }}/version.txt` \
+          docker run --rm -v ${GITHUB_WORKSPACE}/${{ matrix.context.path }}:/.axoned axone-protocol/axoned:`cat ./chains/${{ matrix.context.network }}/version.txt` \
               genesis add-genesis-account validator 1000000000uknow \
-              --home /.okp4d \
+              --home /.axoned \
               --keyring-backend test
 
-          docker run --rm -v ${GITHUB_WORKSPACE}/${{ matrix.context.path }}:/.okp4d okp4/okp4d:`cat ./chains/${{ matrix.context.network }}/version.txt` \
+          docker run --rm -v ${GITHUB_WORKSPACE}/${{ matrix.context.path }}:/.axoned axone-protocol/axoned:`cat ./chains/${{ matrix.context.network }}/version.txt` \
               genesis gentx validator 1000000uknow \
-              --home /.okp4d \
-              --chain-id=okp4-${{ matrix.context.network }} \
+              --home /.axoned \
+              --chain-id=axone-${{ matrix.context.network }} \
               --keyring-backend test
 
-          docker run --rm -v ${GITHUB_WORKSPACE}/${{ matrix.context.path }}:/.okp4d okp4/okp4d:`cat ./chains/${{ matrix.context.network }}/version.txt` \
+          docker run --rm -v ${GITHUB_WORKSPACE}/${{ matrix.context.path }}:/.axoned axone-protocol/axoned:`cat ./chains/${{ matrix.context.network }}/version.txt` \
               genesis collect-gentxs \
-              --home /.okp4d
+              --home /.axoned
 
       - name: Start the blockchain
         run: |
-          docker run --network host --rm --name okp4-node -v ${GITHUB_WORKSPACE}/${{ matrix.context.path }}:/.okp4d okp4/okp4d:`cat ./chains/${{ matrix.context.network }}/version.txt` \
+          docker run --network host --rm --name axone-node -v ${GITHUB_WORKSPACE}/${{ matrix.context.path }}:/.axoned axone-protocol/axoned:`cat ./chains/${{ matrix.context.network }}/version.txt` \
               start \
-              --home /.okp4d \
-              --moniker okp4-node &
+              --home /.axoned \
+              --moniker axone-node &
 
       - name: Wait for blockchain to start
         uses: ifaxity/wait-on-action@v1
@@ -117,4 +117,4 @@ jobs:
 
       - name: Stop the blockchain
         run: |
-          docker stop okp4-node
+          docker stop axone-node

--- a/.github/workflows/update-chains-description.yml
+++ b/.github/workflows/update-chains-description.yml
@@ -44,13 +44,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.OKP4_TOKEN }}
+          token: ${{ secrets.OPS_TOKEN }}
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
         with:
-          gpg_private_key: ${{ secrets.OKP4_BOT_GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.OKP4_BOT_GPG_PASSPHRASE }}
+          gpg_private_key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.BOT_GPG_PASSPHRASE }}
           git_config_global: true
           git_user_signingkey: true
           git_commit_gpgsign: true
@@ -92,9 +92,9 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           message: "docs(networks): update documentation (according to genesis)"
-          author_name: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }}
-          author_email: ${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}
-          committer_name: ${{ secrets.OKP4_BOT_GIT_COMMITTER_NAME }}
-          committer_email: ${{ secrets.OKP4_BOT_GIT_COMMITTER_EMAIL }}
+          author_name: ${{ vars.BOT_GIT_AUTHOR_NAME }}
+          author_email: ${{ vars.BOT_GIT_AUTHOR_EMAIL }}
+          committer_name: ${{ vars.BOT_GIT_COMMITTER_NAME }}
+          committer_email: ${{ vars.BOT_GIT_COMMITTER_EMAIL }}
         env:
-          GITHUB_TOKEN: ${{ secrets.OKP4_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OPS_TOKEN }}

--- a/.github/workflows/update-peers.yml
+++ b/.github/workflows/update-peers.yml
@@ -3,8 +3,9 @@ name: Update peers
 on:
   workflow_dispatch:
 
-  schedule:
-    - cron: "0 0 * * MON"
+  # Disable for now.
+  # schedule:
+  #   - cron: "0 0 * * MON"
 
 concurrency:
   group: update-peers-${{ github.ref }}
@@ -22,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.OKP4_TOKEN }}
+          token: ${{ secrets.OPS_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -30,8 +31,8 @@ jobs:
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
         with:
-          gpg_private_key: ${{ secrets.OKP4_BOT_GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.OKP4_BOT_GPG_PASSPHRASE }}
+          gpg_private_key: ${{ secrets.BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.BOT_GPG_PASSPHRASE }}
           git_config_global: true
           git_user_signingkey: true
           git_commit_gpgsign: true
@@ -90,9 +91,9 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           message: "feat(networks): update peers list"
-          author_name: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }}
-          author_email: ${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}
-          committer_name: ${{ secrets.OKP4_BOT_GIT_COMMITTER_NAME }}
-          committer_email: ${{ secrets.OKP4_BOT_GIT_COMMITTER_EMAIL }}
+          author_name: ${{ vars.BOT_GIT_AUTHOR_NAME }}
+          author_email: ${{ vars.BOT_GIT_AUTHOR_EMAIL }}
+          committer_name: ${{ vars.BOT_GIT_COMMITTER_NAME }}
+          committer_email: ${{ vars.BOT_GIT_COMMITTER_EMAIL }}
         env:
-          GITHUB_TOKEN: ${{ secrets.OKP4_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OPS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
-[![okp4 github banner](https://raw.githubusercontent.com/okp4/.github/main/profile/static/okp4-banner-v2.webp)](https://okp4.network)
+[![axone github banner](https://raw.githubusercontent.com/axone-protocol/.github/main/profile/static/axone-banner.png)](https://axone.xyz)
 
-# 🌐 OKP4 Networks
+# 🌐 Axone Networks
 
-> Genesis and node configuration elements for joining [OKP4 networks](https://docs.okp4.network/docs/nodes/introduction).
+> Genesis and node configuration elements for joining [Axone networks](https://docs.axone.xyz/docs/nodes/introduction).
 
-[![lint](https://img.shields.io/github/actions/workflow/status/okp4/networks/lint.yml?label=Lint&style=for-the-badge&logo=github)](https://github.com/okp4/networks/actions/workflows/lint.yml)
+[![lint](https://img.shields.io/github/actions/workflow/status/axone-protocol/networks/lint.yml?label=Lint&style=for-the-badge&logo=github)](https://github.com/axone-protocol/networks/actions/workflows/lint.yml)
 [![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=for-the-badge&logo=conventionalcommits)](https://conventionalcommits.org)
 [![license](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg?style=for-the-badge)](https://opensource.org/licenses/BSD-3-Clause)
 
-This repository contains the official genesis files and network information for the various [OKP4](https://okp4.network) networks. Additionally, you'll find for each network, the instructions to register your validator node in the genesis, if applicable.
+This repository contains the official genesis files and network information for the various [Axone](https://axone.xyz) networks. Additionally, you'll find for each network, the instructions to register your validator node in the genesis, if applicable.
 
-For a complete description about nodes and validators, check out the [OKP4 Documentation site](https://docs.okp4.network/docs/nodes/introduction).
+For a complete description about nodes and validators, check out the [Axone Documentation site](https://docs.axone.xyz/docs/nodes/introduction).
 
 ## 🔗 Networks
 
 ### [`drunemeton-1`](./chains/drunemeton-1/README.md)
+
+> :warning: This chain was created under the old `OKP4` brand.
 
 [![stability-beta](https://img.shields.io/badge/stability-beta-33bbff.svg)](https://github.com/mkenney/software-guides/blob/master/STABILITY-BADGES.md#beta) ![audience](https://img.shields.io/badge/audience-public-white.svg) ![incentivized-✖️](https://img.shields.io/badge/incentivized-✖️-29220A.svg)
 
@@ -22,9 +24,13 @@ For a complete description about nodes and validators, check out the [OKP4 Docum
 
 ### [`nemeton-1`](./chains/nemeton-1/README.md)
 
+> :warning: This chain was created under the old `OKP4` brand.
+
 [![stability-deprecated](https://img.shields.io/badge/stability-deprecated-922b21.svg)](https://github.com/mkenney/software-guides/blob/master/STABILITY-BADGES.md#deprecated) ![audience](https://img.shields.io/badge/audience-public-white.svg) [![incentivized-💰](https://img.shields.io/badge/incentivized-💰-29220A.svg)](https://nemeton.okp4.network/)
 
 ### [`nemeton`](./chains/nemeton/README.md)
+
+> :warning: This chain was created under the old `OKP4` brand.
 
 [![stability-deprecated](https://img.shields.io/badge/stability-deprecated-922b21.svg)](https://github.com/mkenney/software-guides/blob/master/STABILITY-BADGES.md#deprecated) ![audience](https://img.shields.io/badge/audience-public-white.svg) ![incentivized-✖️](https://img.shields.io/badge/incentivized-✖️-29220A.svg)
 
@@ -34,22 +40,24 @@ We invite all the validators to shutdown their nodes. You can still find more de
 
 ### [`devnet-1`](./chains/devnet-1/README.md)
 
+> :warning: This chain was created under the old `OKP4` brand.
+
 [![stability-experimental](https://img.shields.io/badge/stability-experimental-orange.svg)](https://github.com/mkenney/software-guides/blob/master/STABILITY-BADGES.md#experimental) ![audience](https://img.shields.io/badge/audience-restricted-orange.svg) ![incentivized-✖️](https://img.shields.io/badge/incentivized-✖️-29220A.svg)
 
 The main development network, intended primarily for use by the OKP4 core team. Unstable (the chain can be reinitialized without notice), experimental, with restricted access.
 
 ## 👨‍⚖️ Want to become a validator?
 
-Validators are responsible for securing the okp4 network. Validator responsibilities include maintaining a functional [node](https://docs.okp4.network/docs/nodes/run-node) with constant uptime and providing a sufficient amount of $KNOW as stake. In exchange for this service, validators receive block rewards and transaction fees!
+Validators are responsible for securing the Axone network. Validator responsibilities include maintaining a functional [node](https://docs.axone.xyz/docs/nodes/run-node) with constant uptime and providing a sufficient amount of $AXONE as stake. In exchange for this service, validators receive block rewards and transaction fees!
 
 So, want to become a validator?
 
-<p align="center">👉 <a href="https://docs.okp4.network/docs/nodes/introduction">Checkout the documentation!</a></p>
+<p align="center">👉 <a href="https://docs.axone.xyz/docs/nodes/introduction">Checkout the documentation!</a></p>
 
 And Join the community!
 
 <p align="center">
-  <a href="https://discord.gg/okp4"><img src="/docs/discord.svg" width="64" /></a>
+  <a href="https://discord.gg/axone"><img src="/docs/discord.svg" width="64" /></a>
   &nbsp; &nbsp;
   <a href="https://t.me/okp4network"><img src="/docs/telegram.svg" width="64" /></a>
 </p>


### PR DESCRIPTION
Through this PR we prepare this repository to welcome `Axone` networks instead of `OKP4`.

## Details

Old networks under the `OKP4` branding stays untouched but considered unmanaged anymore by this repository which in their case serves as a history trace. They are marked as is in the main readme.

All the other elements now respects `Axone` brand, as well as the CI is prepared to run under the new organization.