### PR TITLE
Refine network documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,37 +14,12 @@ For a complete description about nodes and validators, check out the [Axone Docu
 
 ## 🔗 Networks
 
-### [`drunemeton-1`](./chains/drunemeton-1/README.md)
+Below is a list of available networks, organized from the most recent to the oldest:
 
-> :warning: This chain was created under the old `OKP4` brand.
-
-[![stability-beta](https://img.shields.io/badge/stability-beta-33bbff.svg)](https://github.com/mkenney/software-guides/blob/master/STABILITY-BADGES.md#beta) ![audience](https://img.shields.io/badge/audience-public-white.svg) ![incentivized-✖️](https://img.shields.io/badge/incentivized-✖️-29220A.svg)
-
-`Drunemeton` is the main OKP4 testnet. Please find more details to join the network [here](chains/drunemeton-1/).
-
-### [`nemeton-1`](./chains/nemeton-1/README.md)
-
-> :warning: This chain was created under the old `OKP4` brand.
-
-[![stability-deprecated](https://img.shields.io/badge/stability-deprecated-922b21.svg)](https://github.com/mkenney/software-guides/blob/master/STABILITY-BADGES.md#deprecated) ![audience](https://img.shields.io/badge/audience-public-white.svg) [![incentivized-💰](https://img.shields.io/badge/incentivized-💰-29220A.svg)](https://nemeton.okp4.network/)
-
-### [`nemeton`](./chains/nemeton/README.md)
-
-> :warning: This chain was created under the old `OKP4` brand.
-
-[![stability-deprecated](https://img.shields.io/badge/stability-deprecated-922b21.svg)](https://github.com/mkenney/software-guides/blob/master/STABILITY-BADGES.md#deprecated) ![audience](https://img.shields.io/badge/audience-public-white.svg) ![incentivized-✖️](https://img.shields.io/badge/incentivized-✖️-29220A.svg)
-
-This was the first OKP4 `testnet` but it is now discontinued.
-
-We invite all the validators to shutdown their nodes. You can still find more details on the network [here](chains/nemeton/).
-
-### [`devnet-1`](./chains/devnet-1/README.md)
-
-> :warning: This chain was created under the old `OKP4` brand.
-
-[![stability-experimental](https://img.shields.io/badge/stability-experimental-orange.svg)](https://github.com/mkenney/software-guides/blob/master/STABILITY-BADGES.md#experimental) ![audience](https://img.shields.io/badge/audience-restricted-orange.svg) ![incentivized-✖️](https://img.shields.io/badge/incentivized-✖️-29220A.svg)
-
-The main development network, intended primarily for use by the OKP4 core team. Unstable (the chain can be reinitialized without notice), experimental, with restricted access.
+- [`drunemeton-1`](./chains/drunemeton-1/README.md)
+- [`nemeton-1`](./chains/nemeton-1/README.md)
+- [`nemeton`](./chains/nemeton/README.md)
+- [`devnet-1`](./chains/devnet-1/README.md)
 
 ## 👨‍⚖️ Want to become a validator?
 

--- a/chains/devnet-1/README.md
+++ b/chains/devnet-1/README.md
@@ -7,6 +7,9 @@
 ![incentivized-✖️](https://img.shields.io/badge/incentivized-✖️-29220A.svg?style=for-the-badge)
 ![genesis-time](https://img.shields.io/badge/%E2%8F%B0%20genesis%20time-2022--05--09T16%3A04%3A18.892191Z-red?style=for-the-badge)
 
+> [!IMPORTANT]
+> This network was originally created under the former `OKP4` brand.
+
 The main development network, intended primarily for use by the OKP4 core team. This `devnet` functions as a "playground" for those looking to experiment with the protocol as a blockchain user, token holder, application developer or network validator.
 
 This network is very unstable, and the whole blockchain can be reset, deleting all blocks.

--- a/chains/devnet-1/README.md.gtpl
+++ b/chains/devnet-1/README.md.gtpl
@@ -7,6 +7,9 @@
 ![incentivized-✖️](https://img.shields.io/badge/incentivized-✖️-29220A.svg?style=for-the-badge)
 ![genesis-time](https://img.shields.io/badge/{{ "⏰" | urlquery }}%20genesis%20time-{{ (datasource "genesis").genesis_time | urlquery | strings.ReplaceAll "-" "--" }}-red?style=for-the-badge)
 
+> [!IMPORTANT]
+> This network was originally created under the former `OKP4` brand.
+
 The main development network, intended primarily for use by the OKP4 core team. This `devnet` functions as a "playground" for those looking to experiment with the protocol as a blockchain user, token holder, application developer or network validator.
 
 This network is very unstable, and the whole blockchain can be reset, deleting all blocks.

--- a/chains/drunemeton-1/README.md
+++ b/chains/drunemeton-1/README.md
@@ -6,6 +6,7 @@
 ![audience](https://img.shields.io/badge/audience-public-white.svg?style=for-the-badge)
 ![incentivized-✖️](https://img.shields.io/badge/incentivized-✖️-29220A.svg?style=for-the-badge)
 ![genesis-time](https://img.shields.io/badge/%E2%8F%B0%20genesis%20time-2024--02--06T15%3A00%3A00Z-red?style=for-the-badge)
+![chain-height](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.drunemeton.okp4.network%2Fcosmos%2Fbase%2Ftendermint%2Fv1beta1%2Fblocks%2Flatest&query=%24.block.header.height&style=for-the-badge&label=height&color=%231E2A4E&cacheSeconds=6)
 
 > [!IMPORTANT]
 > This network was originally created under the former `OKP4` brand.

--- a/chains/drunemeton-1/README.md
+++ b/chains/drunemeton-1/README.md
@@ -7,6 +7,9 @@
 ![incentivized-✖️](https://img.shields.io/badge/incentivized-✖️-29220A.svg?style=for-the-badge)
 ![genesis-time](https://img.shields.io/badge/%E2%8F%B0%20genesis%20time-2024--02--06T15%3A00%3A00Z-red?style=for-the-badge)
 
+> [!IMPORTANT]
+> This network was originally created under the former `OKP4` brand.
+
 ## Register in the Genesis
 
 To register your validator node in the `genesis.json` you just need to provide a signed `gentx` with an initial delegation of `10000000000uknow` in a [⚖️ Register Validator issue](https://github.com/okp4/networks/issues).

--- a/chains/drunemeton-1/README.md.gtpl
+++ b/chains/drunemeton-1/README.md.gtpl
@@ -7,6 +7,9 @@
 ![incentivized-✖️](https://img.shields.io/badge/incentivized-✖️-29220A.svg?style=for-the-badge)
 ![genesis-time](https://img.shields.io/badge/{{ "⏰" | urlquery }}%20genesis%20time-{{ (datasource "genesis").genesis_time | urlquery | strings.ReplaceAll "-" "--" }}-red?style=for-the-badge)
 
+> [!IMPORTANT]
+> This network was originally created under the former `OKP4` brand.
+
 ## Register in the Genesis
 
 To register your validator node in the `genesis.json` you just need to provide a signed `gentx` with an initial delegation of `10000000000uknow` in a [⚖️ Register Validator issue](https://github.com/okp4/networks/issues).

--- a/chains/drunemeton-1/README.md.gtpl
+++ b/chains/drunemeton-1/README.md.gtpl
@@ -6,6 +6,7 @@
 ![audience](https://img.shields.io/badge/audience-public-white.svg?style=for-the-badge)
 ![incentivized-✖️](https://img.shields.io/badge/incentivized-✖️-29220A.svg?style=for-the-badge)
 ![genesis-time](https://img.shields.io/badge/{{ "⏰" | urlquery }}%20genesis%20time-{{ (datasource "genesis").genesis_time | urlquery | strings.ReplaceAll "-" "--" }}-red?style=for-the-badge)
+![chain-height](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.drunemeton.okp4.network%2Fcosmos%2Fbase%2Ftendermint%2Fv1beta1%2Fblocks%2Flatest&query=%24.block.header.height&style=for-the-badge&label=height&color=%231E2A4E&cacheSeconds=6)
 
 > [!IMPORTANT]
 > This network was originally created under the former `OKP4` brand.

--- a/chains/nemeton-1/README.md
+++ b/chains/nemeton-1/README.md
@@ -7,6 +7,9 @@
 [![incentivized-💰](https://img.shields.io/badge/incentivized-💰-29220A.svg?style=for-the-badge)](https://nemeton.okp4.network/)
 ![genesis-time](https://img.shields.io/badge/%E2%8F%B0%20genesis%20time-2022--12--14T15%3A00%3A00Z-red?style=for-the-badge)
 
+> [!IMPORTANT]
+> This network was originally created under the former `OKP4` brand.
+
 ## Register in the Genesis
 
 > ℹ️ **Registration is only open for Druids 🧙‍♂️**. See [Nemeton program](https://nemeton.okp4.network/).

--- a/chains/nemeton-1/README.md.gtpl
+++ b/chains/nemeton-1/README.md.gtpl
@@ -7,6 +7,9 @@
 [![incentivized-💰](https://img.shields.io/badge/incentivized-💰-29220A.svg?style=for-the-badge)](https://nemeton.okp4.network/)
 ![genesis-time](https://img.shields.io/badge/{{ "⏰" | urlquery }}%20genesis%20time-{{ (datasource "genesis").genesis_time | urlquery | strings.ReplaceAll "-" "--" }}-red?style=for-the-badge)
 
+> [!IMPORTANT]
+> This network was originally created under the former `OKP4` brand.
+
 ## Register in the Genesis
 
 > ℹ️ **Registration is only open for Druids 🧙‍♂️**. See [Nemeton program](https://nemeton.okp4.network/).

--- a/chains/nemeton/README.md
+++ b/chains/nemeton/README.md
@@ -8,7 +8,11 @@
 ![genesis-time](https://img.shields.io/badge/%E2%8F%B0%20genesis%20time-2022--10--17T13%3A00%3A00Z-red?style=for-the-badge)
 ![nb-validators](https://img.shields.io/badge/%F0%9F%A7%91%E2%80%8D%E2%9A%96%EF%B8%8F%20core%20validators-10-brightgreen?style=for-the-badge)
 
-> :warning: **This chain was stopped on 30/12/22**. The active testnet is: [nemeton-1](../nemeton-1/README.md).
+> [!IMPORTANT]
+> This network was originally created under the former `OKP4` brand.
+<!-- -->
+> [!IMPORTANT]
+> This network was discontinued on 30/12/22.
 
 ## Register in the Genesis
 

--- a/chains/nemeton/README.md.gtpl
+++ b/chains/nemeton/README.md.gtpl
@@ -8,7 +8,11 @@
 ![genesis-time](https://img.shields.io/badge/{{ "⏰" | urlquery }}%20genesis%20time-{{ (datasource "genesis").genesis_time | urlquery | strings.ReplaceAll "-" "--" }}-red?style=for-the-badge)
 ![nb-validators](https://img.shields.io/badge/{{ "🧑‍⚖️" | urlquery }}%20core%20validators-{{ (datasource "genesis") | jsonpath "$..messages[?(@.min_self_delegation)]" | len }}-brightgreen?style=for-the-badge)
 
-> :warning: **This chain was stopped on 30/12/22**. The active testnet is: [nemeton-1](../nemeton-1/README.md).
+> [!IMPORTANT]
+> This network was discontinued on 30/12/22.
+<!-- -->
+> [!IMPORTANT]
+> This network was originally created under the former `OKP4` brand.
 
 ## Register in the Genesis
 


### PR DESCRIPTION
This PR improves the network documentation by simplifying network references in the `README.md` file for maintainability, explicitly mentioning that the networks were created under the old `OKP4` brand, and - as a bonus - adding a blockchain height badge for the `drunemeton-1` network (using the JSON value extraction from the [blockchain REST API](https://api.drunemeton.okp4.network/#/) via [shields.io](https://shields.io/badges/dynamic-json-badge)).